### PR TITLE
Fix: avoid running estimateGas as execution will fail

### DIFF
--- a/dapp/src/services/Wallet.js
+++ b/dapp/src/services/Wallet.js
@@ -1149,22 +1149,31 @@
       */
       wallet.confirmTransaction = function (address, txId, options, cb) {
         var instance = Web3Service.web3.eth.contract(wallet.json.multiSigDailyLimit.abi).at(address);
-        instance.confirmTransaction.estimateGas(txId, wallet.txDefaults(), function (e, gas){
-          if (e) {
-            cb(e);
-          }
-          else {
-            Web3Service.sendTransaction(
-              instance.confirmTransaction,
-              [
-                txId,
-                wallet.txDefaults({gas: Math.ceil(gas * 1.5)})
-              ],
-              options,
-              cb
-            );
-          }
-        });
+        Web3Service.sendTransaction(
+          instance.confirmTransaction,
+          [
+            txId,
+            wallet.txDefaults({gas: 300000})
+          ],
+          options,
+          cb
+        );
+        // instance.confirmTransaction.estimateGas(txId, wallet.txDefaults(), function (e, gas){
+        //   if (e) {
+        //     cb(e);
+        //   }
+        //   else {
+        //     Web3Service.sendTransaction(
+        //       instance.confirmTransaction,
+        //       [
+        //         txId,
+        //         wallet.txDefaults({gas: Math.ceil(gas * 1.5)})
+        //       ],
+        //       options,
+        //       cb
+        //     );
+        //   }
+        // });
       };
 
       /**
@@ -1189,22 +1198,31 @@
       */
       wallet.executeTransaction = function (address, txId, options, cb) {
         var instance = Web3Service.web3.eth.contract(wallet.json.multiSigDailyLimit.abi).at(address);
-        instance.executeTransaction.estimateGas(txId, wallet.txDefaults(), function (e, gas) {
-          if (e) {
-            cb(e);
-          }
-          else {
-            Web3Service.sendTransaction(
-              instance.executeTransaction,
-              [
-                txId,
-                wallet.txDefaults({gas: Math.ceil(gas * 1.5)})
-              ],
-              options,
-              cb
-            );
-          }
-        });
+        Web3Service.sendTransaction(
+          instance.executeTransaction,
+          [
+            txId,
+            wallet.txDefaults({gas: 300000})
+          ],
+          options,
+          cb
+        );
+        // instance.executeTransaction.estimateGas(txId, wallet.txDefaults(), function (e, gas) {
+        //   if (e) {
+        //     cb(e);
+        //   }
+        //   else {
+        //     Web3Service.sendTransaction(
+        //       instance.executeTransaction,
+        //       [
+        //         txId,
+        //         wallet.txDefaults({gas: Math.ceil(gas * 1.5)})
+        //       ],
+        //       options,
+        //       cb
+        //     );
+        //   }
+        // });
       };
 
       /**
@@ -1303,33 +1321,45 @@
             cb(e);
           }
           else {
-            // estimate gas
-            walletInstance.submitTransaction.estimateGas(
-              tx.to,
-              tx.value,
-              data,
-              count,
-              wallet.txDefaults(),
-              function (e, gas) {
-                if (e) {
-                  cb(e);
-                }
-                else {
-                  Web3Service.sendTransaction(
-                    walletInstance.submitTransaction,
-                    [
-                      tx.to,
-                      tx.value,
-                      data,
-                      count,
-                      wallet.txDefaults({gas: Math.ceil(gas * 1.5)}),
-                    ],
-                    options,
-                    cb
-                  );
-                }
-              }
+            Web3Service.sendTransaction(
+              walletInstance.submitTransaction,
+              [
+                tx.to,
+                tx.value,
+                data,
+                count,
+                wallet.txDefaults({gas: 300000}),
+              ],
+              options,
+              cb
             );
+            // estimate gas
+            // walletInstance.submitTransaction.estimateGas(
+            //   tx.to,
+            //   tx.value,
+            //   data,
+            //   count,
+            //   wallet.txDefaults(),
+            //   function (e, gas) {
+            //     if (e) {
+            //       cb(e);
+            //     }
+            //     else {
+            //       Web3Service.sendTransaction(
+            //         walletInstance.submitTransaction,
+            //         [
+            //           tx.to,
+            //           tx.value,
+            //           data,
+            //           count,
+            //           wallet.txDefaults({gas: Math.ceil(gas * 1.5)}),
+            //         ],
+            //         options,
+            //         cb
+            //       );
+            //     }
+            //   }
+            // );
           }
         }).call();
       };

--- a/dapp/src/services/Wallet.js
+++ b/dapp/src/services/Wallet.js
@@ -1158,22 +1158,6 @@
           options,
           cb
         );
-        // instance.confirmTransaction.estimateGas(txId, wallet.txDefaults(), function (e, gas){
-        //   if (e) {
-        //     cb(e);
-        //   }
-        //   else {
-        //     Web3Service.sendTransaction(
-        //       instance.confirmTransaction,
-        //       [
-        //         txId,
-        //         wallet.txDefaults({gas: Math.ceil(gas * 1.5)})
-        //       ],
-        //       options,
-        //       cb
-        //     );
-        //   }
-        // });
       };
 
       /**
@@ -1207,22 +1191,6 @@
           options,
           cb
         );
-        // instance.executeTransaction.estimateGas(txId, wallet.txDefaults(), function (e, gas) {
-        //   if (e) {
-        //     cb(e);
-        //   }
-        //   else {
-        //     Web3Service.sendTransaction(
-        //       instance.executeTransaction,
-        //       [
-        //         txId,
-        //         wallet.txDefaults({gas: Math.ceil(gas * 1.5)})
-        //       ],
-        //       options,
-        //       cb
-        //     );
-        //   }
-        // });
       };
 
       /**
@@ -1333,33 +1301,6 @@
               options,
               cb
             );
-            // estimate gas
-            // walletInstance.submitTransaction.estimateGas(
-            //   tx.to,
-            //   tx.value,
-            //   data,
-            //   count,
-            //   wallet.txDefaults(),
-            //   function (e, gas) {
-            //     if (e) {
-            //       cb(e);
-            //     }
-            //     else {
-            //       Web3Service.sendTransaction(
-            //         walletInstance.submitTransaction,
-            //         [
-            //           tx.to,
-            //           tx.value,
-            //           data,
-            //           count,
-            //           wallet.txDefaults({gas: Math.ceil(gas * 1.5)}),
-            //         ],
-            //         options,
-            //         cb
-            //       );
-            //     }
-            //   }
-            // );
           }
         }).call();
       };


### PR DESCRIPTION
I left the original code commented so it's easier to compare what was before, I will delete the comments before going from draft to PR.

I think the problem is related to the webpage doing a simulation of the transaction before sending it to Metamask. The provider would simulate the transaction to calculate the gas needed, but they use a gas price lower than the basefee resulting in an error in the simulation. Now that step should be done only *after* the gas configuration window has appeared, allowing us to specify a higher gas price in the modal. The downside is that we have no gas estimation, the upside is that if the transaction would revert or run out of gas, it would not reach Metamask (You can test this by trying to submit a transaction to a wallet to which you are not the owner). I have been testing all functionality and the only step that appears to "jump" the simulation is the ERC-20 withdrawal request, it will let you send a transaction that will revert.